### PR TITLE
Fix stream index bug in pdbtool copy subcommand, add READMEs to crates

### DIFF
--- a/msf/Cargo.toml
+++ b/msf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msf"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Reads Multi-Stream Files, which are used in the Microsoft Program Database (PDB) file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/msf/README.md
+++ b/msf/README.md
@@ -1,48 +1,19 @@
-# PDB tools
+# MSF container layer for Program Database (PDB) library
 
-This repository contains libraries and tools for working with Microsoft Program
-Database (PDB) files. All of the code is in Rust.
-
-* The `ms-pdb-msf` crate contains code for reading, creating, and modifying PDB
-  files that use the MSF container format. Currently, all PDBs produced by
-  Microsoft tools use the MSF container format.
+This crate contains code for reading, creating, and modifying PDB files that use
+the MSF container format. Currently, all PDBs produced by Microsoft tools use
+the MSF container format.
   
-  This is a lower-level building block for PDBs, and most developers will never
-  need to directly use the `ms-pdb-msf` crate. Instead, they should use the
-  `ms-pdb` crate.
-
-* The `ms-pdb-msfz` crate contains code for reading and writing PDB files that
-  use the MSFZ container format. MSFZ is a new container format that is
-  optimized for "cold storage"; PDB/MSFZ files cannot be modified in-place in
-  the way PDB/MSF files can, but MSFZ files use an efficient form of compression
-  that allows data to be accessed without decompressing the entire file. MSFZ is
-  intended to be a format for storing PDBs, not for local development.
-
-  Most developers will not need to use the `ms-pdb-msfz` crate directly.
-  Instead, they should use the `ms-pdb` crate.
-
-* The `ms-pdb` crate supports reading, creating, and modifying PDB files. It
-  builds on the `ms-pdb-msf` and `ms-pdb-msfz` crate. The `ms-pdb-msf` and
-  `ms-pdb-msfz` crates provide the container format for PDB, but they do not
-  contain any code for working with the contents of PDBs. That is the job of the
-  `ms-pdb` crate -- it provides methods for reading specific PDB data
-  structures, such as debug symbols, line mappings, module records, etc.
+This is a lower-level building block for PDBs. Most developers should use the
+[`ms-pdb`](https://crates.io/crates/ms-pdb) crate, instead of directly using the `ms-pdb-msf` crate.
+The `ms-pdb-msf` crate is published separately to aid in minimizing dependencies and enforcing
+good layering.
 
 ## All information in this implementation is based on publicly-available information
 
-With the exception of MSFZ, this implementation is based solely on public
-sources that describe the PDB and MSF data structures. This repository does not
-contain any confidential Microsoft intellectual property.
-
-## MSFZ describes an **experimental** data format and is subject to change without notice
-
-The MSFZ specification in this repository describes an experimental container
-format for PDBs. **Microsoft makes no commitment to the stability or support for
-MSFZ.** The MSFZ format may be changed or discontinued at any time, without any
-notice or obligation for Microsoft to take any action. At some future point,
-Microsoft _may_ make a support commitment to MSFZ (possibly with incompatible
-changes made to it), but this repository does not imply any commitment or
-agreement to do so.
+This implementation is based solely on public sources that describe the PDB and
+MSF data structures. This repository does not contain any confidential Microsoft
+intellectual property.
 
 ## **THIS IMPLEMENTATION IS NOT AUTHORITATIVE AND IS NOT A REFERENCE IMPLEMENTATION**
 

--- a/msf/src/lib.rs
+++ b/msf/src/lib.rs
@@ -176,6 +176,13 @@ pub type PageSize = Pow2;
 /// applications.
 pub const STREAM_DIR_STREAM: u32 = 0;
 
+/// The maximum valid stream index.
+///
+/// Although this library uses `u32` for stream indices, many MSF and PDB data structures assume
+/// that stream numbers cab be stored in `u16`. Also, `0xffff` is used as a sentinel value in
+/// some data structures, so that value cannot be a valid stream index.
+pub const MAX_STREAM: u32 = 0xfffe;
+
 /// Converts a page number to a file offset.
 fn page_to_offset(page: u32, page_size: PageSize) -> u64 {
     (page as u64) << page_size.exponent()

--- a/msfz/Cargo.toml
+++ b/msfz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msfz"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Reads Compressed Multi-Stream Files, which is part of the Microsoft PDB file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -27,11 +27,11 @@ zerocopy = { workspace = true, features = ["alloc", "derive"] }
 zerocopy-derive.workspace = true
 
 [dependencies.ms-pdb-msf]
-version = "0.1.0"
+version = "0.1.1"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]
-version = "0.1.0"
+version = "0.1.1"
 path = "../msfz"
 
 [dev-dependencies]

--- a/pdb/README.md
+++ b/pdb/README.md
@@ -1,48 +1,14 @@
-# PDB tools
+# Rust support for reading and writing Program Database (PDB) files
 
-This repository contains libraries and tools for working with Microsoft Program
-Database (PDB) files. All of the code is in Rust.
-
-* The `ms-pdb-msf` crate contains code for reading, creating, and modifying PDB
-  files that use the MSF container format. Currently, all PDBs produced by
-  Microsoft tools use the MSF container format.
-  
-  This is a lower-level building block for PDBs, and most developers will never
-  need to directly use the `ms-pdb-msf` crate. Instead, they should use the
-  `ms-pdb` crate.
-
-* The `ms-pdb-msfz` crate contains code for reading and writing PDB files that
-  use the MSFZ container format. MSFZ is a new container format that is
-  optimized for "cold storage"; PDB/MSFZ files cannot be modified in-place in
-  the way PDB/MSF files can, but MSFZ files use an efficient form of compression
-  that allows data to be accessed without decompressing the entire file. MSFZ is
-  intended to be a format for storing PDBs, not for local development.
-
-  Most developers will not need to use the `ms-pdb-msfz` crate directly.
-  Instead, they should use the `ms-pdb` crate.
-
-* The `ms-pdb` crate supports reading, creating, and modifying PDB files. It
-  builds on the `ms-pdb-msf` and `ms-pdb-msfz` crate. The `ms-pdb-msf` and
-  `ms-pdb-msfz` crates provide the container format for PDB, but they do not
-  contain any code for working with the contents of PDBs. That is the job of the
-  `ms-pdb` crate -- it provides methods for reading specific PDB data
-  structures, such as debug symbols, line mappings, module records, etc.
+This crate provides the ability to read and write Program Database (PDB) files. PDB files
+contain debugging symbols and other information used by debuggers and development tools,
+when targeting the Windows operating system.
 
 ## All information in this implementation is based on publicly-available information
 
 With the exception of MSFZ, this implementation is based solely on public
 sources that describe the PDB and MSF data structures. This repository does not
 contain any confidential Microsoft intellectual property.
-
-## MSFZ describes an **experimental** data format and is subject to change without notice
-
-The MSFZ specification in this repository describes an experimental container
-format for PDBs. **Microsoft makes no commitment to the stability or support for
-MSFZ.** The MSFZ format may be changed or discontinued at any time, without any
-notice or obligation for Microsoft to take any action. At some future point,
-Microsoft _may_ make a support commitment to MSFZ (possibly with incompatible
-changes made to it), but this repository does not imply any commitment or
-agreement to do so.
 
 ## **THIS IMPLEMENTATION IS NOT AUTHORITATIVE AND IS NOT A REFERENCE IMPLEMENTATION**
 

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdbtool/README.md
+++ b/pdbtool/README.md
@@ -1,0 +1,174 @@
+# Program Database (PDB) tool
+
+This is a simple tool for reading Program Database files. It uses the
+[`ms-pdb`](https://crates.io/crates/ms-pdb) crate to read and write PDB.
+
+This tool is published as a separate crate in order to minimize the dependencies of the `ms-pdb`
+crate.
+
+## Installation
+
+```batch
+cargo install pdbtool
+```
+
+## Examples
+
+```
+pdbtool dump hello_world.pdb streams
+```
+
+produces:
+
+```text
+Stream #     0 : (size          0) OldStreamDir
+Stream #     1 : (size        665) PDB
+Stream #     2 : (size   15341432) TPI
+Stream #     3 : (size    1668945) DBI
+Stream #     4 : (size    1871280) IPI
+Stream #     5 : (size          0) Named { name: "/LinkInfo" }
+Stream #     6 : (size          0) Named { name: "/TMCache" }
+Stream #     7 : (size     140696) Named { name: "/names" }
+[...]
+```
+
+Use `pdbtool --help` for a list of commands. Use `pdbtool dump --help` for help with the `dump`
+command, which has many subcommands.
+
+## Help
+
+```batch
+pdbtool --help
+```
+
+```text
+Usage: pdbtool [OPTIONS] <COMMAND>
+
+Commands:
+  add-src     Adds source file contents to the PDB. The contents are embedded directly within the PDB. WinDbg and Visual Studio can both extract the source files
+  copy        Copies a PDB from one file to another. All stream contents are preserved exactly, byte-for-byte. The blocks within streams are laid out sequentially
+  test        
+  dump        
+  save        
+  find        Searches the DBI Section Contributions table
+  find-name   Searches the TPI Stream for a given type
+  counts      Counts the number of records and record sizes for a given set of PDBs
+  hexdump     Dumps part of a file (any file, not just a PDB) as a hex dump. If you want to dump a specific stream, then use the `dump <filename> hex` command instead
+  pdz-encode  
+  help        Print this message or the help of the given subcommand(s)
+
+Options:
+      --quiet       Reduce logging to just warnings and errors in `mspdb` and `pdbtool` modules
+      --verbose     Turn on debug output in all `mspdb` and `pdbtool` modules. Noisy!
+      --timestamps  Show timestamps in log messages
+      --tracy       Connect to Tracy (diagnostics tool). Requires that the `tracy` Cargo feature be enabled
+  -h, --help        Print help
+```
+
+## Help - dump
+
+The `dump` subcommand takes a path to a PDB file as its next argument, followed by a subcommand,
+as seen in the example above.
+
+```batch
+pdbtool dump --help
+```
+
+```text
+Usage: pdbtool dump [OPTIONS] <PDB> <COMMAND>
+
+Commands:
+  names                
+  globals              
+  tpi                  Dump the Type Stream (TPI)
+  ipi                  Dump the Id Stream (TPI)
+  dbi                  Dump DBI header
+  dbi-enc              Dump DBI Edit-and-Continue Substream
+  dbi-type-server-map  
+  gsi                  Global Symbol Index. Loads the GSI and iterates through its hash records. For each one, finds the symbol record in the GSS and displays it
+  psi                  Public Symbol Index. Loads the PSI and iterates through its hash records. For each one, finds the symbol record in the GSS and displays it
+  modules              
+  streams              Dump the Stream Directory
+  lines                Dumps C13 Line Data for a given module
+  sources              Dump the DBI Stream - Sources substream
+  section-map          
+  section-contribs     Dump section contributions (quite large!)
+  pdbi                 Dump the PDB Info Stream
+  module-symbols       Displays the symbols for a specific module
+  hex                  Dump the contents of a stream, or a subsection of it, using a hexadecimal dump format. By default, this will only show a portion of the stream; use `--len` to increase it
+  help                 Print this message or the help of the given subcommand(s)
+
+Arguments:
+  <PDB>  The PDB to dump
+
+Options:
+      --lines-like-cvdump  
+  -h, --help               Print help
+```
+
+## Converting PDB files to Compressed PDB (PDZ/MSFZ)
+
+> **WARNING** **WARNING** **WARNING** **WARNING** **WARNING**
+>
+> This tool provides an _experimental_ capability for compressing PDBs into a new PDB container
+> format, called MSFZ. See the [MSFZ Container Specification](https://github.com/microsoft/pdb-rs/blob/main/msfz/src/msfz.md).
+> This container specification is _experimental_ and is not guaranteed to be stable. It may change
+> at any time; there is no guarantee of compatibility, stability, or reliability. It is defined
+> for the purposes of experimentation.
+>
+> **WARNING** **WARNING** **WARNING** **WARNING** **WARNING**
+
+MSFZ is intended to reduce development costs, by defining a compression format for PDB, which
+still allows tools (such as debuggers) to read from compressed PDBs by decompressing only those
+parts of the PDB that are needed. This avoids the need to decompress the entire PDB. See the
+specification (linked above) for details.
+
+To convert a PDB file to a compressed PDB:
+
+```batch
+pdbtool pdz-encode hello_world.pdb d:\compressed_pdbs\hello_world.pdb
+```
+
+This reads the `hello_world.pdb`, compresses its contents, and writes it to
+`d:\compressed_pdbs\hello_world.pdb`. Recent versions of the Windows Debugger
+(WinDbg) can directly read compressed PDB files. _It cannot be over-emphasized
+that this support is experimental, and subject to change without notice._
+
+## Contributing
+
+This project welcomes contributions and suggestions. Most contributions require
+you to agree to a Contributor License Agreement (CLA) declaring that you have
+the right to, and actually do, grant us the rights to use your contribution. For
+details, visit https://cla.opensource.microsoft.com.
+
+When you submit a pull request, a CLA bot will automatically determine whether
+you need to provide a CLA and decorate the PR appropriately (e.g., status check,
+comment). Simply follow the instructions provided by the bot. You will only need
+to do this once across all repos using our CLA.
+
+This project has adopted the
+[Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
+For more information see the
+[Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
+contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
+additional questions or comments.
+
+## Trademarks
+
+This project may contain trademarks or logos for projects, products, or
+services. Authorized use of Microsoft trademarks or logos is subject to and must
+follow
+[Microsoft's Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general).
+Use of Microsoft trademarks or logos in modified versions of this project must
+not cause confusion or imply Microsoft sponsorship. Any use of third-party
+trademarks or logos are subject to those third-party's policies.
+
+## Repository
+
+* <https://github.com/microsoft/pdb-rs>
+
+## Contacts
+
+* `sivadeilra` on GitHub
+* Arlie Davis ardavis@microsoft.com
+

--- a/pdbtool/src/copy.rs
+++ b/pdbtool/src/copy.rs
@@ -18,11 +18,8 @@ pub fn copy_command(options: &Options) -> anyhow::Result<()> {
     for stream_index in 1..src.num_streams() {
         if src.is_stream_valid(stream_index) {
             let stream_data = src.read_stream_to_vec(stream_index)?;
-            let (_, mut s) = dst.new_stream()?;
+            let mut s = dst.write_stream(stream_index)?;
             s.write_all(&stream_data)?;
-        } else {
-            let dst_stream_index = dst.nil_stream()?;
-            assert_eq!(dst_stream_index, stream_index);
         }
     }
 


### PR DESCRIPTION
Add README.md files for each crate

Change how `Msfz::write_stream` works (simpler; more reliable; more obvious contract). This fixes a stream index bug in `pdbtool`.
