### PR TITLE
Relax requirements when opening PDB/MSF files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msf"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msf/Cargo.toml
+++ b/msf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msf"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Reads Multi-Stream Files, which are used in the Microsoft Program Database (PDB) file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -27,7 +27,7 @@ zerocopy = { workspace = true, features = ["alloc", "derive"] }
 zerocopy-derive.workspace = true
 
 [dependencies.ms-pdb-msf]
-version = "0.1.2"
+version = "0.1.3"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -30,6 +30,6 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.3"
+version = "0.1.4"
 path = "../pdb"
 

--- a/pdbtool/src/main.rs
+++ b/pdbtool/src/main.rs
@@ -116,12 +116,12 @@ fn configure_tracing(args: &CommandWithFlags) {
     let builder = tracing_subscriber::fmt();
 
     let max_level = if args.quiet {
-        LevelFilter::WARN
+        LevelFilter::ERROR
     } else if args.verbose {
         LevelFilter::DEBUG
     } else {
         LevelFilter::INFO
     };
 
-    builder.with_max_level(max_level).finish();
+    builder.with_max_level(max_level).init();
 }


### PR DESCRIPTION
This is a workaround for a bug in Clang's PDB/MSF code. Clang's implementation will sometimes assign stream pages to pages that are reserved for the Free Page Map (FPM). This is a spec violation, but unfortunately most PDB/MSF implementations don't catch this.

The implementation in this repo caught the violation. However, it will take some time to fix Clang's implementation and then to propagate the fix.  Meanwhile, this PR relaxes the requirement when opening PDB/MSF files for read-only access.  If a PDB/MSF file is being opened for read-write access and it contains this spec violation, then the attempt to open the file will be rejected.
