### PR TITLE
Implement workaround for 16 KB read bug in MSVC code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msfz"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bstr",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msfz/Cargo.toml
+++ b/msfz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msfz"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Reads Compressed Multi-Stream Files, which is part of the Microsoft PDB file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -31,7 +31,7 @@ version = "0.1.3"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]
-version = "0.1.3"
+version = "0.1.4"
 path = "../msfz"
 
 [dev-dependencies]

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -30,6 +30,5 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.4"
+version = "0.1.5"
 path = "../pdb"
-

--- a/pdbtool/src/main.rs
+++ b/pdbtool/src/main.rs
@@ -123,5 +123,5 @@ fn configure_tracing(args: &CommandWithFlags) {
         LevelFilter::INFO
     };
 
-    builder.with_max_level(max_level).init();
+    builder.with_max_level(max_level).with_ansi(false).init();
 }

--- a/pdbtool/tests/encode.rs
+++ b/pdbtool/tests/encode.rs
@@ -1,0 +1,46 @@
+use std::{path::Path, process::Command};
+
+const TMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");
+const PDBTOOL: &str = env!("CARGO_BIN_EXE_pdbtool");
+
+#[test]
+fn min_size_workaround() {
+    let dir = Path::new(TMP_DIR).join("min_size_workaround");
+    _ = std::fs::create_dir_all(&dir);
+
+    let pdb_file_name = dir.join("test.pdb");
+    let pdz_file_name = dir.join("test.pdz");
+
+    // Create a very small test.pdb file
+    {
+        let mut pdb = ms_pdb::msf::Msf::create(&pdb_file_name, Default::default()).unwrap();
+        let mut sw = pdb.write_stream(10).unwrap();
+        sw.write_all_at_mut(b"Hello, world!", 0).unwrap();
+        pdb.commit().unwrap();
+    }
+
+    // Directly read the PDB file
+    {
+        let pdb = ms_pdb::msf::Msf::open(&pdb_file_name).unwrap();
+        let stream_contents = pdb.read_stream_to_vec(10).unwrap();
+        assert_eq!(stream_contents.as_slice(), b"Hello, world!");
+    }
+
+    // Convert the PDB file to a PDZ file.
+    {
+        let mut cmd = Command::new(PDBTOOL);
+        cmd.arg("--verbose");
+        cmd.arg("pdz-encode");
+        cmd.arg(&pdb_file_name);
+        cmd.arg(&pdz_file_name);
+        cmd.arg("--pad16k");
+        assert!(cmd.status().unwrap().success());
+    }
+
+    // Read the PDZ file and verify the contents of the stream.
+    {
+        let pdz = ms_pdb::msfz::Msfz::open(&pdz_file_name).unwrap();
+        let stream_contents = pdz.read_stream(10).unwrap();
+        assert_eq!(stream_contents.as_slice(), b"Hello, world!");
+    }
+}


### PR DESCRIPTION
This implements a workaround for the PDZ reader bug in the first version of the PDZ decoder compiled into DIA and other MSVC-derived tools. That code fails to open any PDZ file whose size is less than 16 KB, even if the file contents are valid. That bug has been fixed, but propagating that fix throughout the tools ecosystem will take time.

Meanwhile, this PR allows encoders to optionally avoid this problem by zero-padding PDZ files to 16 KB.