### PR TITLE
Add S_HOTPATCHFUNC symbol record

### DIFF
--- a/pdb/src/syms.rs
+++ b/pdb/src/syms.rs
@@ -1003,9 +1003,9 @@ impl<'a> Parse<'a> for FunctionList<'a> {
     fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
         let num_funcs = p.u32()? as usize;
         let funcs: &[ItemIdLe] = p.slice(num_funcs)?;
-        let num_invocations = num_funcs.min(p.len() / size_of::<U32<LE>>());
-        let invocations = p.slice(num_invocations)?;
-        Ok(Self { funcs, counts: invocations })
+        let num_counts = num_funcs.min(p.len() / size_of::<U32<LE>>());
+        let counts = p.slice(num_counts)?;
+        Ok(Self { funcs, counts })
     }
 }
 

--- a/pdb/src/syms.rs
+++ b/pdb/src/syms.rs
@@ -57,20 +57,45 @@ pub struct BlockHeader {
     pub p_end: U32<LE>,
 }
 
-/// Used for the header of S_LPROC32 and S_GPROC32.
+/// Used for the header of procedure symbols. This is used for `S_LPROC32`, `S_GPROC32`,
+/// `S_LPROC32_ID`, etc.
 ///
 /// See `PROCSYM32` in `cvinfo.h`.
 #[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Unaligned, Debug)]
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct ProcFixed {
+    /// This field is always zero; procedure symbols never have parents.
     pub p_parent: U32<LE>,
+
+    /// The byte offset, relative to the start of this procedure record, of the `S_END` symbol that
+    /// closes the scope of this symbol record.
     pub p_end: U32<LE>,
+
     pub p_next: U32<LE>,
+
+    /// The length in bytes of the procedure instruction stream.
     pub proc_len: U32<LE>,
+
+    /// The offset in bytes from the start of the procedure to the point where the stack frame has
+    /// been set up. Parameter and frame variables can be viewed at this point.
     pub debug_start: U32<LE>,
+
+    /// The offset in bytes from the start of the procedure to the point where the procedure is
+    /// ready to return and has calculated its return value, if any. Frame and register variables
+    /// can still be viewed.
     pub debug_end: U32<LE>,
+
+    /// This field is either a `TypeIndex` that points into the TPI or is an `ItemId` that
+    /// points into the IPI.
+    ///
+    /// This field is a `TypeIndex` for the following symbols: `S_GPROC32`, `S_LPROC32`,
+    /// `S_LPROC32EX`, `S_LPROC32_DPC`, `S_GPROC32EX`.
+    ///
+    /// This field is a `ItemId` for `S_LPROC32_ID`, `S_GPROC32_ID`, `S_LPROC32_DPC_ID`,
+    /// `S_GPROC32EX_ID`, `S_LPROC32EX_ID`.
     pub proc_type: TypeIndexLe,
+
     pub offset_segment: OffsetSegment,
     pub flags: u8,
 }
@@ -959,25 +984,28 @@ impl<'a> Parse<'a> for Label<'a> {
     }
 }
 
-/// `S_CALLERS` or `S_CALLEES`
+/// Data for `S_CALLERS`, `S_CALLEES`, `S_INLINEES`.
 #[derive(Clone, Debug)]
 pub struct FunctionList<'a> {
     /// The list of functions, in the IPI. Each is either `LF_FUNC_ID` or `LF_MFUNC_ID`.
     pub funcs: &'a [ItemIdLe],
 
-    /// Invocation counts. The items in `invocations` parallel the items in `funcs`, but the length
-    /// of `invocations` can be less than the length of `funcs`. Unmatched functions are assumed
-    /// to have an invocation count of zero.
-    pub invocations: &'a [U32<LE>],
+    /// Counts for each function.
+    ///
+    /// The values in `counts` parallel the items in `funcs`, but the length of `invocations` can be
+    /// less than the length of `funcs`. Unmatched counts are assumed to be zero.
+    ///
+    /// This is empty for `S_INLINEES`.
+    pub counts: &'a [U32<LE>],
 }
 
 impl<'a> Parse<'a> for FunctionList<'a> {
     fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
-        let count = p.u32()?;
-        let funcs: &[ItemIdLe] = p.slice(count as usize)?;
-        let num_invocations = p.len() / size_of::<U32<LE>>();
+        let num_funcs = p.u32()? as usize;
+        let funcs: &[ItemIdLe] = p.slice(num_funcs)?;
+        let num_invocations = num_funcs.min(p.len() / size_of::<U32<LE>>());
         let invocations = p.slice(num_invocations)?;
-        Ok(Self { funcs, invocations })
+        Ok(Self { funcs, counts: invocations })
     }
 }
 
@@ -1148,6 +1176,25 @@ impl<'a> Iterator for AnnotationIterStrings<'a> {
     }
 }
 
+/// Hot-patched function
+#[derive(Clone, Debug)]
+pub struct HotPatchFunc<'a> {
+    /// ID of the function
+    pub func: ItemId,
+
+    /// The name of the function
+    pub name: &'a BStr,
+}
+
+impl<'a> Parse<'a> for HotPatchFunc<'a> {
+    fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
+        Ok(Self {
+            func: p.u32()?,
+            name: p.strz()?,
+        })
+    }
+}
+
 // Trampoline subtypes
 
 /// Incremental thunks
@@ -1193,6 +1240,7 @@ pub enum SymData<'a> {
     HeapAllocSite(&'a HeapAllocSite),
     ManagedProc(ManagedProc<'a>),
     Annotation(Annotation<'a>),
+    HotPatchFunc(HotPatchFunc<'a>),
 }
 
 impl<'a> SymData<'a> {
@@ -1255,6 +1303,7 @@ impl<'a> SymData<'a> {
             SymKind::S_HEAPALLOCSITE => Self::HeapAllocSite(p.get()?),
             SymKind::S_GMANPROC | SymKind::S_LMANPROC => Self::ManagedProc(p.parse()?),
             SymKind::S_ANNOTATION => Self::Annotation(p.parse()?),
+            SymKind::S_HOTPATCHFUNC => Self::HotPatchFunc(p.parse()?),
 
             _ => Self::Unknown,
         })

--- a/pdb/src/syms/kind.rs
+++ b/pdb/src/syms/kind.rs
@@ -170,6 +170,7 @@ sym_kinds! {
     0x1165, S_LDATA_HLSL32_EX;
     0x1167, S_FASTLINK;
     0x1168, S_INLINEES;
+    0x1169, S_HOTPATCHFUNC;
 }
 
 impl std::fmt::Debug for SymKind {
@@ -216,6 +217,21 @@ impl SymKind {
                 | SymKind::S_SEPCODE
                 | SymKind::S_GMANPROC
                 | SymKind::S_LMANPROC
+        )
+    }
+
+    /// True if this `SymKind` is a procedure definition.
+    pub fn is_proc(self) -> bool {
+        matches!(
+            self,
+            SymKind::S_GPROC32
+                | SymKind::S_GPROC32_ID
+                | SymKind::S_GPROC32_ST
+                | SymKind::S_LPROC32
+                | SymKind::S_LPROC32_DPC
+                | SymKind::S_LPROC32_DPC_ID
+                | SymKind::S_LPROC32_ID
+                | SymKind::S_LPROC32_ST
         )
     }
 

--- a/pdbtool/src/dump.rs
+++ b/pdbtool/src/dump.rs
@@ -42,6 +42,9 @@ pub enum Subcommand {
     Globals {
         max: Option<usize>,
         skip: Option<usize>,
+        /// Show types
+        #[arg(short, long)]
+        types: bool,
     },
     /// Dump the Type Stream (TPI)
     Tpi(types::DumpTypeStreamOptions),
@@ -114,8 +117,8 @@ pub fn dump_main(options: DumpOptions) -> anyhow::Result<()> {
     }
 
     match options.subcommand {
-        Subcommand::Globals { skip, max } => {
-            sym::dump_globals(&p, skip, max, false)?;
+        Subcommand::Globals { skip, max, types } => {
+            sym::dump_globals(&p, skip, max, false, types)?;
         }
 
         Subcommand::Names(args) => {

--- a/pdbtool/src/dump/sym.rs
+++ b/pdbtool/src/dump/sym.rs
@@ -218,6 +218,10 @@ pub fn dump_sym(
             write!(out, "{} ", site.offset)?;
             ty_ref(out, context, site.func_type.get())?;
         }
+
+        SymData::HotPatchFunc(hp) => {
+            write!(out, "0x{:x} : {}", hp.func, hp.name)?;
+        }
     }
 
     writeln!(out)?;
@@ -262,6 +266,7 @@ pub fn dump_globals(
     skip_opt: Option<usize>,
     max_opt: Option<usize>,
     show_bytes: bool,
+    show_types: bool,
 ) -> anyhow::Result<()> {
     println!("Global symbols:");
     let gss = p.gss()?;
@@ -275,6 +280,7 @@ pub fn dump_globals(
         max_opt,
         0,
         show_bytes,
+        show_types,
     )?;
     Ok(())
 }
@@ -287,6 +293,7 @@ pub fn dump_symbol_stream(
     max_opt: Option<usize>,
     stream_offset: u32,
     show_bytes: bool,
+    show_types: bool,
 ) -> anyhow::Result<()> {
     let mut iter = SymIter::new(symbol_records).with_ranges();
 
@@ -303,6 +310,7 @@ pub fn dump_symbol_stream(
     let mut num_found = 0;
     let mut out = String::new();
     let mut context = DumpSymsContext::new(type_stream, ipi);
+    context.show_type_index = show_types;
 
     for (record_range, sym) in iter {
         out.clear();
@@ -383,6 +391,7 @@ pub fn dump_module_symbols(pdb: &Pdb, options: DumpModuleSymbols) -> anyhow::Res
         options.max,
         4,
         options.bytes,
+        false,
     )?;
 
     println!();


### PR DESCRIPTION
The S_HOTPATCHFUNC symbol identifies a function that has been generated for a hotpatch.
