### PR TITLE
Make stream directory compression optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msfz"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bstr",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msfz/Cargo.toml
+++ b/msfz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msfz"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Reads Compressed Multi-Stream Files, which is part of the Microsoft PDB file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/msfz/src/reader.rs
+++ b/msfz/src/reader.rs
@@ -6,7 +6,7 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
 use std::sync::{Arc, OnceLock};
 use sync_file::{RandomAccessFile, ReadAt};
-use tracing::{debug, debug_span, info, info_span, trace, trace_span};
+use tracing::{debug, debug_span, info_span, trace, trace_span};
 use zerocopy::IntoBytes;
 
 /// Reads MSFZ files.
@@ -147,7 +147,7 @@ impl<F: ReadAt> Msfz<F> {
         let stream_dir_size_compressed = header.stream_dir_size_compressed.get() as usize;
         let stream_dir_file_offset = header.stream_dir_offset.get();
         let stream_dir_compression = header.stream_dir_compression.get();
-        info!(
+        debug!(
             num_streams,
             stream_dir_size_uncompressed,
             stream_dir_size_compressed,
@@ -188,7 +188,7 @@ impl<F: ReadAt> Msfz<F> {
         let mut chunk_table: Box<[ChunkEntry]> =
             map_alloc_error(FromZeros::new_box_zeroed_with_elems(num_chunks))?;
         if num_chunks != 0 {
-            info!(
+            debug!(
                 num_chunks,
                 chunk_table_offset, "reading compressed chunk table"
             );

--- a/msfz/src/tests.rs
+++ b/msfz/src/tests.rs
@@ -50,9 +50,6 @@ where
     let cursor: Cursor<Vec<u8>> = Cursor::new(Vec::new());
     let mut w = MsfzWriter::new(cursor).unwrap();
 
-    // Make debugging easier
-    w.set_stream_dir_compression(None);
-
     f(&mut w);
 
     info!("Streams:");

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -31,7 +31,7 @@ version = "0.1.3"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]
-version = "0.1.4"
+version = "0.1.5"
 path = "../msfz"
 
 [dev-dependencies]

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -30,5 +30,5 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.5"
+version = "0.1.6"
 path = "../pdb"


### PR DESCRIPTION
Although MSFZ supports stream directory compression, not all readers support it.  This change makes stream directory compression optional.