### PR TITLE
Fix stream dir bug, make DBI compression smarter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,7 +357,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -399,7 +399,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msfz"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "bstr",
@@ -476,7 +476,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msfz/Cargo.toml
+++ b/msfz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msfz"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 description = "Reads Compressed Multi-Stream Files, which is part of the Microsoft PDB file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/msfz/src/reader.rs
+++ b/msfz/src/reader.rs
@@ -174,6 +174,9 @@ impl<F: ReadAt> Msfz<F> {
                 &mut stream_dir_bytes,
             )?;
         } else {
+            if stream_dir_size_uncompressed != stream_dir_size_compressed {
+                bail!("This PDZ file is invalid. The Stream Directory is not compressed, but has inconsistent compressed vs. uncompressed sizes.");
+            }
             file.read_exact_at(stream_dir_bytes.as_mut_bytes(), stream_dir_file_offset)?;
         }
 

--- a/msfz/src/writer.rs
+++ b/msfz/src/writer.rs
@@ -326,6 +326,7 @@ impl<F: Write + Seek> MsfzWriterFile<F> {
         })
     }
 
+    #[inline(never)]
     fn finish_current_chunk(&mut self) -> std::io::Result<()> {
         let _span = debug_span!("finish_current_chunk").entered();
 

--- a/msfz/src/writer.rs
+++ b/msfz/src/writer.rs
@@ -228,7 +228,7 @@ impl<F: Write + Seek> MsfzWriter<F> {
             self.file.out.write_all(&stream_dir_compressed_bytes)?;
         } else {
             self.file.out.write_all(&stream_dir_bytes)?;
-            stream_dir_size_compressed = 0;
+            stream_dir_size_compressed = stream_dir_size_uncompressed;
             stream_dir_compression = COMPRESSION_NONE;
         }
 

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -31,7 +31,7 @@ version = "0.1.3"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]
-version = "0.1.5"
+version = "0.1.6"
 path = "../msfz"
 
 [dev-dependencies]

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -30,5 +30,5 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.6"
+version = "0.1.7"
 path = "../pdb"

--- a/pdbtool/src/pdz/encode.rs
+++ b/pdbtool/src/pdz/encode.rs
@@ -1,12 +1,14 @@
 use crate::pdz::util::*;
 use anyhow::{Context, Result};
+use ms_pdb::dbi::{DbiStreamHeader, DBI_STREAM_HEADER_LEN};
 use ms_pdb::msf::Msf;
-use ms_pdb::msfz::{MsfzFinishOptions, MsfzWriter, MIN_FILE_SIZE_16K};
+use ms_pdb::msfz::{MsfzFinishOptions, MsfzWriter, StreamWriter, MIN_FILE_SIZE_16K};
 use ms_pdb::Stream;
 use std::fs::File;
 use std::io::{Seek, SeekFrom, Write};
 use std::path::Path;
-use tracing::{trace, trace_span};
+use tracing::{trace, trace_span, warn};
+use zerocopy::FromBytes;
 
 #[derive(clap::Parser, Debug)]
 pub(crate) struct PdzEncodeOptions {
@@ -46,6 +48,26 @@ pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
     let num_streams = pdb.num_streams();
     writer.reserve_num_streams(num_streams as usize);
 
+    // The PDBI is a very important stream and we want to write its uncompressed form at the
+    // very beginning of the output file, so that it can be easily found using the "initial read"
+    // optimization.
+    {
+        let _span = trace_span!("transfer PDBI stream");
+        pdb.read_stream_to_vec_mut(Stream::PDB.into(), &mut stream_data)?;
+        let mut sw = writer.stream_writer(Stream::PDB.into())?;
+        sw.set_compression_enabled(false);
+        sw.write_all(&stream_data)?;
+    }
+
+    // Next, write the DBI stream.
+    {
+        let _span = trace_span!("transfer DBI stream");
+        pdb.read_stream_to_vec_mut(Stream::DBI.into(), &mut stream_data)?;
+        let mut sw = writer.stream_writer(Stream::DBI.into())?;
+        write_dbi(&mut sw, &stream_data)?;
+    }
+
+    // Loop through the rest of the streams and do normal chunked compression.
     for stream_index in 1..num_streams {
         if !pdb.is_stream_valid(stream_index) {
             // This is a nil stream. We don't need to do anything because the writer has already
@@ -53,10 +75,14 @@ pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
             continue;
         }
 
+        if stream_index == Stream::PDB.into() || stream_index == Stream::DBI.into() {
+            // We have already processed these streams, above.
+            continue;
+        }
+
         let _span = trace_span!("stream").entered();
         trace!(stream_index);
 
-        stream_data.clear();
         {
             let _span = trace_span!("read stream").entered();
             pdb.read_stream_to_vec_mut(stream_index, &mut stream_data)?;
@@ -66,14 +92,6 @@ pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
         {
             let _span = trace_span!("write stream").entered();
             let mut sw = writer.stream_writer(stream_index)?;
-
-            // Don't compress the PDBI. The PDBI is very small, so compression is useless, and this
-            // exercises the non-compressed option. It also makes it possible to read the PDBI in
-            // a hex dump.
-            if stream_index == Stream::PDB.into() {
-                sw.set_compression_enabled(false);
-            }
-
             sw.write_all(&stream_data)?;
         }
     }
@@ -99,6 +117,96 @@ pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
     // Explicitly close our file handles so that the replace_file() call can succeed.
     drop(pdb);
     drop(file);
+
+    Ok(())
+}
+
+/// Write the DBI stream. Be smart about compression and compression chunk boundaries.
+fn write_dbi(sw: &mut StreamWriter<'_, File>, stream_data: &[u8]) -> Result<()> {
+    // Avoid compressing data from the DBI stream with other chunks.
+    sw.end_chunk()?;
+
+    if stream_data.len() < DBI_STREAM_HEADER_LEN {
+        // Something is seriously wrong with this PDB. Pass the contents through without any
+        // modification or compression.
+        sw.set_compression_enabled(false);
+        // sw.write_all(stream_data)?;
+        return Ok(());
+    }
+
+    let (header_bytes, mut rest_of_stream) = stream_data.split_at(DBI_STREAM_HEADER_LEN);
+
+    // This unwrap() cannot fail because we just tested the size, above.
+    let dbi_header = DbiStreamHeader::ref_from_bytes(header_bytes).unwrap();
+
+    // Write the DBI Stream Header uncompressed. This allows symbol.exe to read it.
+    sw.set_compression_enabled(false);
+    sw.write_all(header_bytes)?;
+
+    // The DBI consists of a header, followed by a set of substreams. The substreams contain
+    // data with different sizes, compression characteristic, and different access patterns.
+    //
+    // We attempt to break up the rest of the stream data and handle each substream individually.
+    // If we find a substream size that doesn't make sense (is negative or exceeds the size of
+    // the remaining data in the stream) then we just bail and write the rest of the data without
+    // doing any more chunking.
+
+    'fallback: {
+        macro_rules! get_next_substream {
+            ($substream_len_field:ident) => {
+                {
+                    let Ok(len_u32) = u32::try_from(dbi_header.$substream_len_field.get()) else {
+                        warn!("DBI stream is invalid; the substream {} has a negative length", stringify!($substream_len_field));
+                        break 'fallback;
+                    };
+                    let len_usize = len_u32 as usize;
+                    if rest_of_stream.len() < len_usize {
+                        warn!("DBI stream is invalid; the substream {} has a length that exceeds the size of the remaining stream data.", stringify!($substream_len_field));
+                        break 'fallback;
+                    }
+                    let (lo, hi) = rest_of_stream.split_at(len_usize);
+                    rest_of_stream = hi;
+                    lo
+                }
+            }
+        }
+
+        // Module Info
+        let modules = get_next_substream!(mod_info_size);
+        sw.set_compression_enabled(true);
+        sw.write_all(modules)?;
+        sw.end_chunk()?;
+
+        // The "Section Contributions" substream is very large and is not often used, so we place
+        // it in its own chunk, too.
+        let section_contributions = get_next_substream!(section_contribution_size);
+        sw.set_compression_enabled(true);
+        sw.write_all(section_contributions)?;
+        sw.end_chunk()?;
+
+        // The "Section Map" is very small. We write it without compression.
+        let section_map = get_next_substream!(section_map_size);
+        sw.set_compression_enabled(false);
+        sw.write_all(section_map)?;
+        sw.end_chunk()?;
+
+        // The "Sources" substream is very commonly accessed and medium-sized. We store it in its
+        // own chunk.
+        let sources = get_next_substream!(source_info_size);
+        sw.set_compression_enabled(true);
+        sw.write_all(sources)?;
+        sw.end_chunk()?;
+
+        // The "Type Server Map", "Optional Debug Headers", and "Edit-and-Continue" substreams are
+        // typically very small and rarely accessed. We store them compressed.
+    }
+
+    // If we got here, then either something is wrong with the contents of the stream, or we just
+    // reached the last few substreams, and we don't do anything special with them. Write the rest
+    // of the data.
+    sw.set_compression_enabled(true);
+    sw.write_all(rest_of_stream)?;
+    sw.end_chunk()?;
 
     Ok(())
 }

--- a/pdbtool/src/pdz/encode.rs
+++ b/pdbtool/src/pdz/encode.rs
@@ -130,7 +130,7 @@ fn write_dbi(sw: &mut StreamWriter<'_, File>, stream_data: &[u8]) -> Result<()> 
         // Something is seriously wrong with this PDB. Pass the contents through without any
         // modification or compression.
         sw.set_compression_enabled(false);
-        // sw.write_all(stream_data)?;
+        sw.write_all(stream_data)?;
         return Ok(());
     }
 

--- a/pdbtool/tests/encode.rs
+++ b/pdbtool/tests/encode.rs
@@ -3,8 +3,8 @@ use ms_pdb::msf::Msf;
 use ms_pdb::msfz::Msfz;
 use ms_pdb::{Stream, StreamIndexU16};
 use std::io::Write;
-use std::{path::Path, process::Command};
-use zerocopy::little_endian::U32;
+use std::path::Path;
+use std::process::Command;
 use zerocopy::{FromBytes, IntoBytes};
 
 const TMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");

--- a/pdbtool/tests/encode.rs
+++ b/pdbtool/tests/encode.rs
@@ -1,7 +1,34 @@
+use ms_pdb::dbi::{DbiStreamHeader, DBI_STREAM_HEADER_LEN, DBI_STREAM_VERSION_V110};
+use ms_pdb::msf::Msf;
+use ms_pdb::msfz::Msfz;
+use ms_pdb::{Stream, StreamIndexU16};
+use std::io::Write;
 use std::{path::Path, process::Command};
+use zerocopy::little_endian::U32;
+use zerocopy::{FromBytes, IntoBytes};
 
 const TMP_DIR: &str = env!("CARGO_TARGET_TMPDIR");
 const PDBTOOL: &str = env!("CARGO_BIN_EXE_pdbtool");
+
+#[track_caller]
+fn run_command(mut cmd: Command) {
+    let mut s = String::new();
+    s.push_str(cmd.get_program().to_str().unwrap());
+    for arg in cmd.get_args() {
+        s.push(' ');
+        s.push_str(arg.to_str().unwrap());
+    }
+
+    println!("Running: {}", s);
+
+    let status = cmd.status().expect("Failed to execute command");
+
+    if !status.success() {
+        panic!("Command failed: {}", status.code().unwrap());
+    }
+
+    println!();
+}
 
 #[test]
 fn min_size_workaround() {
@@ -13,7 +40,7 @@ fn min_size_workaround() {
 
     // Create a very small test.pdb file
     {
-        let mut pdb = ms_pdb::msf::Msf::create(&pdb_file_name, Default::default()).unwrap();
+        let mut pdb = Msf::create(&pdb_file_name, Default::default()).unwrap();
         let mut sw = pdb.write_stream(10).unwrap();
         sw.write_all_at_mut(b"Hello, world!", 0).unwrap();
         pdb.commit().unwrap();
@@ -21,7 +48,7 @@ fn min_size_workaround() {
 
     // Directly read the PDB file
     {
-        let pdb = ms_pdb::msf::Msf::open(&pdb_file_name).unwrap();
+        let pdb = Msf::open(&pdb_file_name).unwrap();
         let stream_contents = pdb.read_stream_to_vec(10).unwrap();
         assert_eq!(stream_contents.as_slice(), b"Hello, world!");
     }
@@ -38,8 +65,156 @@ fn min_size_workaround() {
 
     // Read the PDZ file and verify the contents of the stream.
     {
-        let pdz = ms_pdb::msfz::Msfz::open(&pdz_file_name).unwrap();
+        let pdz = Msfz::open(&pdz_file_name).unwrap();
         let stream_contents = pdz.read_stream(10).unwrap();
         assert_eq!(stream_contents.as_slice(), b"Hello, world!");
     }
+}
+
+fn make_good_dbi() -> Vec<u8> {
+    // Make up some subsections.  The \0s are there to pad to multiples of 4.
+    let module_info = b"I am the module info!\0\0\0";
+    let section_contributions = b"This is totally a section contributions substream!\0\0";
+    let section_map = b"What if this were a section map?";
+    let source_info = b"It would be awesome if this was a source info substream.";
+    let type_server_map = b"If I were a type server map, where would I be?\0\0";
+    let optional_dbg_header = b"You get a debug header! And you get a debug header!\0";
+    let edit_and_continue = b"I can barely edit at all, much less edit and continue!\0\0";
+
+    // Make up a reasonable DBI stream header.
+    let good_dbi_header = DbiStreamHeader {
+        signature: (-1).into(),
+        version: DBI_STREAM_VERSION_V110.into(),
+        age: 1.into(),
+        global_symbol_index_stream: StreamIndexU16::NIL,
+        build_number: 0.into(),
+        public_symbol_index_stream: StreamIndexU16::NIL,
+        pdb_dll_version: 0.into(),
+        global_symbol_stream: StreamIndexU16::NIL,
+        pdb_dll_rbld: 0.into(),
+        mod_info_size: (module_info.len() as i32).into(),
+        section_contribution_size: (section_contributions.len() as i32).into(),
+        section_map_size: (section_map.len() as i32).into(),
+        source_info_size: (source_info.len() as i32).into(),
+        type_server_map_size: (type_server_map.len() as i32).into(),
+        mfc_type_server_index: 0.into(),
+        optional_dbg_header_size: (optional_dbg_header.len() as i32).into(),
+        edit_and_continue_size: (edit_and_continue.len() as i32).into(),
+        flags: 0.into(),
+        machine: 0.into(),
+        padding: 0.into(),
+    };
+
+    let mut good_dbi: Vec<u8> = Vec::new();
+    good_dbi.extend_from_slice(good_dbi_header.as_bytes());
+    good_dbi.extend_from_slice(module_info);
+    good_dbi.extend_from_slice(section_contributions);
+    good_dbi.extend_from_slice(section_map);
+    good_dbi.extend_from_slice(source_info);
+    good_dbi.extend_from_slice(type_server_map);
+    good_dbi.extend_from_slice(optional_dbg_header);
+    good_dbi.extend_from_slice(edit_and_continue);
+
+    good_dbi
+}
+
+// Test roundtrip with a PDB with a reasonable DBI stream
+#[test]
+fn dbi_good() {
+    let dbi = make_good_dbi();
+    dbi_case("good", &dbi);
+}
+
+// Test roundtrip with a DBI that is too small to be valid.
+#[test]
+fn dbi_header_too_small() {
+    dbi_case("dbi_header_too_small", b"this is bad");
+}
+
+// Test roundtrip with a DBI that has a valid header, but is cut off within the Module Info substream.
+#[test]
+fn dbi_cut_off_in_module_info() {
+    let dbi = make_good_dbi();
+    dbi_case(
+        "dbi_cut_off_in_module_info",
+        &dbi[..DBI_STREAM_HEADER_LEN + 10],
+    );
+}
+
+#[test]
+fn dbi_cut_off_in_section_contributions() {
+    let dbi = make_good_dbi();
+    let header = DbiStreamHeader::ref_from_prefix(&dbi).unwrap().0;
+    dbi_case(
+        "dbi_cut_off_in_section_contributions",
+        &dbi[..DBI_STREAM_HEADER_LEN + header.mod_info_size.get() as usize + 4],
+    );
+}
+
+#[test]
+fn dbi_cut_off_in_section_map() {
+    let dbi = make_good_dbi();
+    let header = DbiStreamHeader::ref_from_prefix(&dbi).unwrap().0;
+    dbi_case(
+        "dbi_cut_off_in_section_map",
+        &dbi[..DBI_STREAM_HEADER_LEN
+            + header.mod_info_size.get() as usize
+            + header.section_contribution_size.get() as usize
+            + 4],
+    );
+}
+
+// Test roundtrip with only a header
+#[test]
+fn dbi_only_header() {
+    let dbi = make_good_dbi();
+    dbi_case("dbi_only_header", &dbi[..DBI_STREAM_HEADER_LEN]);
+}
+
+// Poke some bogus values into length fields
+#[test]
+fn dbi_negative_module_info() {
+    let mut dbi = make_good_dbi();
+    let header = DbiStreamHeader::mut_from_prefix(&mut dbi).unwrap().0;
+    header.mod_info_size = (-4).into();
+    dbi_case("dbi_negative_module_info", &dbi);
+}
+
+/// Write out a PDB with the DBI contents provided, convert it to PDZ, read the data back,
+/// verify we got the same data.
+#[inline(never)]
+#[track_caller]
+fn dbi_case(name: &str, original_dbi_data: &[u8]) {
+    println!(
+        "dbi_case: DBI stream length: {0} 0x{0:x}",
+        original_dbi_data.len()
+    );
+
+    let dir = Path::new(TMP_DIR).join("dbi_chunking");
+    _ = std::fs::create_dir_all(&dir);
+
+    let pdb_file_name = dir.join(format!("{name}.pdb"));
+    let pdz_file_name = dir.join(format!("{name}.pdz"));
+
+    {
+        let mut pdb = Msf::create(&pdb_file_name, Default::default()).unwrap();
+        let mut sw = pdb.write_stream(Stream::DBI.into()).unwrap();
+        sw.write_all(original_dbi_data).unwrap();
+        drop(sw);
+        pdb.commit().unwrap();
+    }
+
+    // Convert it to a PDZ
+    let mut cmd = Command::new(PDBTOOL);
+    cmd.arg("pdz-encode");
+    cmd.arg(&pdb_file_name);
+    cmd.arg(&pdz_file_name);
+    run_command(cmd);
+
+    // Open the PDZ and verify a few things
+    let pdz = Msfz::open(&pdz_file_name).unwrap();
+    let readback_dbi_data = pdz.read_stream(Stream::DBI.into()).unwrap();
+
+    // Don't use assert_eq!() here; the data is too large and the debug display is not useful.
+    assert!(readback_dbi_data.as_slice() == original_dbi_data);
 }

--- a/pdbtool/tests/encode.rs
+++ b/pdbtool/tests/encode.rs
@@ -29,7 +29,6 @@ fn min_size_workaround() {
     // Convert the PDB file to a PDZ file.
     {
         let mut cmd = Command::new(PDBTOOL);
-        cmd.arg("--verbose");
         cmd.arg("pdz-encode");
         cmd.arg(&pdb_file_name);
         cmd.arg(&pdz_file_name);


### PR DESCRIPTION
* Fix stream dir size when generating an uncompressed stream dir (bug)

* Be smarter about chunk boundaries for the DBI stream and do not compress the DBI stream header.
