### PR TITLE
Remove redundant `Contribution` field prefixes

### DIFF
--- a/pdb/src/lines.rs
+++ b/pdb/src/lines.rs
@@ -509,10 +509,10 @@ pub struct ColumnRecord {
 #[repr(C)]
 #[allow(missing_docs)]
 pub struct Contribution {
-    pub contribution_offset: U32<LE>,
-    pub contribution_segment: U16<LE>,
+    pub offset: U32<LE>,
+    pub segment: U16<LE>,
     pub flags: U16<LE>,
-    pub contribution_size: U32<LE>,
+    pub size: U32<LE>,
     // Followed by a sequence of block records. Each block is variable-length and begins with
     // BlockHeader.
 }

--- a/pdbtool/src/dump/lines.rs
+++ b/pdbtool/src/dump/lines.rs
@@ -67,9 +67,9 @@ fn dump_module_lines(
                 let contribution = ms_pdb::lines::LinesSubsection::parse(subsection.data)?;
                 println!(
                     "    contribution: offset 0x{:x}, segment {}, size {}",
-                    contribution.contribution.contribution_offset,
-                    contribution.contribution.contribution_segment,
-                    contribution.contribution.contribution_size
+                    contribution.contribution.offset,
+                    contribution.contribution.segment,
+                    contribution.contribution.size
                 );
 
                 for block in contribution.blocks() {
@@ -207,7 +207,7 @@ pub fn dump_lines_like_cvdump(p: &Pdb, dbi_stream: &DbiStream<Vec<u8>>) -> Resul
             match subsection.kind {
                 SubsectionKind::LINES => {
                     let lines = LinesSubsection::parse(subsection.data)?;
-                    let contribution_offset = lines.contribution.contribution_offset.get();
+                    let contribution_offset = lines.contribution.offset.get();
 
                     for block in lines.blocks() {
                         if let Some(checksums) = &checksums {


### PR DESCRIPTION
Remove redundant prefixing from the fields of `Contribution`. This makes the naming internally consistent (`flags` is already unprefixed) and aligns `Contribution` with other structs across the project.