### PR TITLE
Derive `Copy` for `OffsetSegment`

### DIFF
--- a/codeview/src/syms.rs
+++ b/codeview/src/syms.rs
@@ -280,7 +280,7 @@ pub struct Pub<'a> {
 impl<'a> Pub<'a> {
     /// Gets the `segment:offset` of this symbol.
     pub fn offset_segment(&self) -> OffsetSegment {
-        self.fixed.offset_segment.clone()
+        self.fixed.offset_segment
     }
 }
 

--- a/codeview/src/syms/offset_segment.rs
+++ b/codeview/src/syms/offset_segment.rs
@@ -3,7 +3,7 @@ use super::*;
 /// Stores an `offset` and `segment` pair, in that order. This structure is directly embedded in
 /// on-disk structures.
 #[repr(C)]
-#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Unaligned, Default, Clone, Eq)]
+#[derive(IntoBytes, FromBytes, Immutable, KnownLayout, Unaligned, Default, Clone, Copy, Eq)]
 pub struct OffsetSegment {
     /// The offset in bytes of a symbol within a segment.
     pub offset: U32<LE>,

--- a/pdb/src/globals/psi.rs
+++ b/pdb/src/globals/psi.rs
@@ -217,7 +217,7 @@ impl PublicSymbolIndex {
 /// Sorts an address map slice.
 #[inline(never)]
 pub fn sort_address_records(addr_map: &mut [(u32, OffsetSegment)]) {
-    addr_map.sort_unstable_by_key(|(record_offset, os)| (os.clone(), *record_offset));
+    addr_map.sort_unstable_by_key(|(record_offset, os)| (*os, *record_offset));
 }
 
 /// Builds the Public Symbol Index (PSI).


### PR DESCRIPTION
`OffsetSegment` already impls `Clone`, and since it fits in a `u64`, it is cheap. Impl `Copy` for better usability.