### PR TITLE
Workarounds for PDZ deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
         toolchain:
-          - 1.88
+          - 1.82
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,7 @@ jobs:
           - windows-latest
           - ubuntu-latest
         toolchain:
-          - 1.82
-          - stable
+          - 1.88
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msf"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msf/Cargo.toml
+++ b/msf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msf"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Reads Multi-Stream Files, which are used in the Microsoft Program Database (PDB) file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -31,7 +31,7 @@ version = "0.1.1"
 path = "../codeview"
 
 [dependencies.ms-pdb-msf]
-version = "0.1.3"
+version = "0.1.4"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -30,5 +30,5 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.9"
+version = "0.1.10"
 path = "../pdb"

--- a/pdbtool/src/check.rs
+++ b/pdbtool/src/check.rs
@@ -97,7 +97,7 @@ fn check_one(options: &CheckOptions, stats: &mut Stats, file_name: &Path) {
                 let mut all_errors_text = String::new();
                 for error in errors.iter() {
                     all_errors_text.push_str(error);
-                    all_errors_text.push_str("\n");
+                    all_errors_text.push('\n');
                 }
 
                 error!("{} : has errors:\n", all_errors_text);

--- a/pdbtool/src/check.rs
+++ b/pdbtool/src/check.rs
@@ -1,0 +1,150 @@
+use anyhow::{bail, Context, Result};
+use ms_pdb::{Pdb, RandomAccessFile};
+use std::path::{Path, PathBuf};
+use tracing::{error, info, warn};
+
+/// Checks whether a given PDB is well-formed (not corrupted).
+/// Can check more than one PDB at a time.
+///
+/// The default behavior is to open the PDB and do nothing else. This simulates
+/// the most basic behavior of any tool that reads a PDB. Additional checks
+/// may be enabled by setting flags.
+#[derive(clap::Parser)]
+pub(crate) struct CheckOptions {
+    /// The files to check.
+    pub(crate) files: Vec<String>,
+
+    #[arg(long)]
+    pub check_modules: bool,
+}
+
+pub(crate) fn command(mut options: CheckOptions) -> Result<()> {
+    if options.files.is_empty() {
+        bail!("You must specify at least one file name (or file pattern) to check.");
+    }
+
+    let mut all_files: Vec<PathBuf> = Vec::with_capacity(options.files.len());
+
+    for file_or_glob in std::mem::take(&mut options.files) {
+        if file_or_glob.contains(['*', '?']) {
+            let mut found_any = false;
+
+            for file_name in glob::glob(&file_or_glob)
+                .with_context(|| format!("File pattern: {file_or_glob}"))?
+            {
+                let file_name =
+                    file_name.with_context(|| format!("File pattern: {file_or_glob}"))?;
+                all_files.push(file_name);
+                found_any = true;
+            }
+
+            if !found_any {
+                warn!("File pattern did not match any files: {file_or_glob}");
+            }
+        } else {
+            all_files.push(file_or_glob.into());
+        }
+    }
+
+    let show_stat = |name: &str, value: u32| {
+        info!("{:<40} : {:8}", name, value);
+    };
+
+    if all_files.len() > 1 {
+        show_stat("Number of PDBs to check", all_files.len() as u32);
+    }
+
+    let mut stats = Stats::default();
+
+    for file_name in all_files.iter() {
+        stats.num_files_checked += 1;
+        check_one(&options, &mut stats, Path::new(file_name));
+    }
+
+    info!("Results:");
+    show_stat("Number of PDBs checked", stats.num_files_checked);
+    show_stat("Number of PDBs with errors", stats.num_files_failed);
+
+    if stats.num_portable_pdbs != 0 {
+        show_stat("Number of portable PDBs (ignored)", stats.num_portable_pdbs);
+    }
+    if stats.num_unknown_files != 0 {
+        show_stat(
+            "Number of unrecognized files (ignored)",
+            stats.num_unknown_files,
+        );
+    }
+
+    Ok(())
+}
+
+#[derive(Default)]
+struct Stats {
+    pub num_files_checked: u32,
+    pub num_files_failed: u32,
+    pub num_portable_pdbs: u32,
+    pub num_unknown_files: u32,
+}
+
+fn check_one(options: &CheckOptions, stats: &mut Stats, file_name: &Path) {
+    let mut errors: Vec<String> = Vec::new();
+
+    match check_one_err(options, stats, &mut errors, file_name) {
+        Ok(()) => {
+            if !errors.is_empty() {
+                stats.num_files_failed += 1;
+
+                let mut all_errors_text = String::new();
+                for error in errors.iter() {
+                    all_errors_text.push_str(error);
+                    all_errors_text.push_str("\n");
+                }
+
+                error!("{} : has errors:\n", all_errors_text);
+            }
+        }
+        Err(e) => {
+            error!("{} : failed: {:?}", file_name.display(), e);
+            stats.num_files_failed += 1;
+        }
+    }
+}
+
+fn check_one_err(
+    options: &CheckOptions,
+    stats: &mut Stats,
+    errors: &mut Vec<String>,
+    file_name: &Path,
+) -> Result<()> {
+    let f = RandomAccessFile::open(file_name)?;
+
+    use ms_pdb::taster::{what_flavor, Flavor};
+    match what_flavor(&f)? {
+        Some(Flavor::Pdb | Flavor::Pdz) => {}
+
+        Some(Flavor::PortablePdb) => {
+            stats.num_portable_pdbs += 1;
+            return Ok(());
+        }
+
+        None => {
+            stats.num_unknown_files += 1;
+            return Ok(());
+        }
+    }
+
+    let pdb = Pdb::open_from_random_file(f)?;
+
+    if options.check_modules {
+        let modules = pdb.modules().with_context(|| "failed to get modules")?;
+        let sources = pdb.sources().with_context(|| "failed to get sources")?;
+
+        let mod_vec: Vec<_> = modules.iter().collect();
+
+        if mod_vec.len() != sources.num_modules() {
+            errors.push(format!("The number of DBI modules is not the same as the number of entries in the DBI Sources map.  {} vs {}", mod_vec.len(), sources.num_modules()));
+        }
+    }
+
+    Ok(())
+}

--- a/pdbtool/src/main.rs
+++ b/pdbtool/src/main.rs
@@ -9,6 +9,7 @@
 use clap::Parser;
 
 mod addsrc;
+mod check;
 mod container;
 mod copy;
 mod counts;
@@ -66,6 +67,7 @@ enum Command {
     /// specific stream, then use the `dump <filename> hex` command instead.
     Hexdump(hexdump::HexdumpOptions),
     PdzEncode(pdz::encode::PdzEncodeOptions),
+    Check(check::CheckOptions),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -84,6 +86,7 @@ fn main() -> anyhow::Result<()> {
         Command::Hexdump(args) => hexdump::command(args)?,
         Command::PdzEncode(args) => pdz::encode::pdz_encode(args)?,
         Command::Container(args) => container::container_command(&args)?,
+        Command::Check(args) => check::command(args)?,
     }
 
     Ok(())
@@ -123,5 +126,9 @@ fn configure_tracing(args: &CommandWithFlags) {
         LevelFilter::INFO
     };
 
-    builder.with_max_level(max_level).with_ansi(false).init();
+    builder
+        .with_max_level(max_level)
+        .with_ansi(false)
+        .without_time()
+        .init();
 }


### PR DESCRIPTION
* Add a new `--copy-unrecognized` flag to `pdz-encode`. This will copy files whose contents are not recognized, such as Portable PDBs.
* Do not validate the contents of the FPM when opening a file for read-only access. Some tools (including tools that MS uses) do not generate valid FPMs.