### PR TITLE
Fix/udt properties mocom bitfield

### DIFF
--- a/codeview/src/types/records.rs
+++ b/codeview/src/types/records.rs
@@ -22,9 +22,9 @@ bitfield::bitfield! {
     pub scoped,        set_scoped:        8;      // scoped definition
     pub hasuniquename, set_hasuniquename: 9;      // true if there is a decorated name following the regular name
     pub sealed,        set_sealed:        10;     // true if class cannot be used as a base class
-    pub hfa,           set_hfa:           12, 11; // CV_HFA (bits 12-11)
+    pub hfa,           set_hfa:           12, 11; // CV_HFA
     pub intrinsic,     set_intrinsic:     13;     // true if class is an intrinsic type (e.g. __m128d)
-    pub mocom,         set_mocom:         15, 14; // CV_MOCOM_UDT (bits 15-14)
+    pub mocom,         set_mocom:         15, 14; // CV_MOCOM_UDT
 }
 
 #[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned)]


### PR DESCRIPTION
# Fix a few bitfield bit-order bugs

## Overview

Encountered some bitfield errors when parsing ntdll.pdb, turns out there's a few areas the bitfield ordering was wrong.

Enjoy the AI summary below :P

## Problem

Four bitfield definitions in `codeview/src/types/records.rs` had reversed bit ordering, causing "attempt to shift right with overflow" panics when parsing PDB files.

## Root Cause

The `bitfield` crate v0.14.0 uses `(msb, lsb)` syntax where **msb must be ≥ lsb**. The width is calculated as `width = msb - lsb + 1`. When bits are specified in reversed order (lsb, msb), this produces a negative width, causing overflow panics during bit extraction.

**Example from bitfield documentation:**
```rust
get_version, _: 3, 0;    // bits 3 down to 0 (4 bits) ✅ Correct
get_ecn, _: 15, 14;      // bits 15 down to 14 (2 bits) ✅ Correct
```

## Bugs Fixed

### 1. UdtProperties.hfa (line 25)
```diff
-pub hfa, set_hfa: 11, 12;  // ❌ width = 11 - 12 + 1 = 0
+pub hfa, set_hfa: 12, 11;  // ✅ width = 12 - 11 + 1 = 2 bits
```
**Spec:** Microsoft `cvinfo.h` defines `unsigned short hfa :2;` at bits 11-12 (CV_HFA_e enum)

### 2. UdtProperties.mocom (line 27)
```diff
-pub mocom, set_mocom: 14, 15;  // ❌ width = 14 - 15 + 1 = 0
+pub mocom, set_mocom: 15, 14;  // ✅ width = 15 - 14 + 1 = 2 bits
```
**Spec:** Microsoft `cvinfo.h` defines `unsigned short mocom :2;` at bits 14-15 (CV_MOCOM_UDT_e enum)

### 3. TypeModifierBits.reserved (line 233)
```diff
-pub reserved, set_reserved: 3, 15;  // ❌ width = 3 - 15 + 1 = -11 (PANIC!)
+pub reserved, set_reserved: 15, 3;  // ✅ width = 15 - 3 + 1 = 13 bits
```
**Impact:** Would panic on any TypeModifier with reserved bits set

### 4. PointerFlags.size (line 368)
```diff
-pub size, set_size: 13, 18;  // ❌ width = 13 - 18 + 1 = -4 (PANIC!)
+pub size, set_size: 18, 13;  // ✅ width = 18 - 13 + 1 = 6 bits
```
**Spec:** Microsoft `cvinfo.h` defines pointer size field at bits 13-18 (6 bits)

### Test Results
Tested with Windows 11 SDK `ntdll.pdb`:

**Before fixes:**
```
thread 'main' panicked at bitfield-0.14.0\src\lib.rs:681:1:
attempt to shift right with overflow
[... hundreds of panics ...]
```

**After fixes:**
```
Parsing PDB: ntdll.pdb
Found 987 global data symbols
Found 38834 types
Found 13248 IPI types
✅ SUCCESS: No panics!
```

## Specification Alignment

All fixes align with Microsoft's official `cvinfo.h` specification from the microsoft/pdb repository:

```c
// CV_prop_t (UdtProperties)
typedef struct CV_prop_t {
    unsigned short hfa    :2;     // bits 11-12 ✅
    unsigned short mocom  :2;     // bits 14-15 ✅
} CV_prop_t;

// CV_modifier_t (TypeModifierBits)
typedef struct CV_modifier_t {
    unsigned short reserved :13;  // bits 3-15 ✅
} CV_modifier_t;

// CV_ptrtype_e size field (PointerFlags)
// Pointer size occupies bits 13-18 ✅
```

## References

- Microsoft PDB specification: https://github.com/microsoft/pdb
- Bitfield crate documentation: https://docs.rs/bitfield/0.14.0/bitfield/
- cvinfo.h: https://github.com/microsoft/pdb/blob/master/include/cvinfo.h

## Commits

- `4b5f321` - Fix UdtProperties hfa and mocom bitfield definitions
- `52ca8d0` - Fix all bitfield bit-order bugs in codeview/types/records.rs
