### PR TITLE
Validate Paths for copy and pdz-encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/pdbtool/src/copy.rs
+++ b/pdbtool/src/copy.rs
@@ -12,6 +12,11 @@ pub struct Options {
 }
 
 pub fn copy_command(options: &Options) -> anyhow::Result<()> {
+    if options.source_pdb.to_string_lossy().eq_ignore_ascii_case(&options.dest_pdb.to_string_lossy())
+    {
+        anyhow::bail!("`source_pdb` and `dest_pdb` must be different paths");
+    }
+
     let src = Pdb::open(&options.source_pdb)?;
     let mut dst = ms_pdb::msf::Msf::create(&options.dest_pdb, Default::default())?;
 
@@ -26,4 +31,31 @@ pub fn copy_command(options: &Options) -> anyhow::Result<()> {
     dst.commit()?;
 
     Ok(())
+}
+
+#[test]
+fn copy_errors_when_paths_differ_only_by_case() {
+    let mut dir = std::env::temp_dir();
+    dir.push("pdbtool_copy_test");
+    let _ = std::fs::create_dir_all(&dir);
+
+    let input = dir.join("same.pdb");
+    let output = dir.join("Same.pdb");
+
+    let opts = Options {
+        source_pdb: PathBuf::from(&input),
+        dest_pdb: PathBuf::from(&output),
+    };
+
+    let res = copy_command(&opts);
+    assert!(
+        res.is_err(),
+        "expected error when paths differ only by case"
+    );
+    let msg = res.unwrap_err().to_string();
+    assert!(
+        msg.contains("must be different"),
+        "unexpected error message: {}",
+        msg
+    );
 }

--- a/pdbtool/src/pdz/encode.rs
+++ b/pdbtool/src/pdz/encode.rs
@@ -37,6 +37,10 @@ pub(crate) struct PdzEncodeOptions {
 pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
     let _span = trace_span!("pdz_encode").entered();
 
+    if options.input_pdb.eq_ignore_ascii_case(&options.output_pdz) {
+        anyhow::bail!("`input_pdb` and `output_pdz` must be different paths");
+    }
+
     let pdb_metadata = std::fs::metadata(&options.input_pdb).with_context(|| {
         format!(
             "Failed to get metadata for input PDB: {}",


### PR DESCRIPTION
* Returns paths must be different for copy and pdz-encode commands
* Same paths currently will fail with: Error: failed to fill whole buffer and lose content on the input file
* Update pdbtool version to 0.1.13