### PR TITLE
Fix file sharing modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bitfield",
@@ -396,7 +396,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msf"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "ms-pdb-msfz"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "bstr",
@@ -485,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "pdbtool"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "bitvec",

--- a/msf/Cargo.toml
+++ b/msf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msf"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "Reads Multi-Stream Files, which are used in the Microsoft Program Database (PDB) file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/msf/src/lib.rs
+++ b/msf/src/lib.rs
@@ -56,7 +56,7 @@ use anyhow::bail;
 use bitvec::prelude::{BitVec, Lsb0};
 use pow2::{IntOnlyPow2, Pow2};
 use std::collections::HashMap;
-use std::fs::File;
+use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom};
 use std::mem::size_of;
 use std::path::Path;
@@ -468,3 +468,30 @@ pub fn is_file_header_msf(header: &[u8]) -> bool {
 /// This does not specify the minimum valid size of an MSF file. It is only a recommended minimum
 /// for callers of [`is_file_header_msf`].
 pub const MIN_FILE_HEADER_SIZE: usize = 0x100;
+
+#[doc(hidden)]
+pub fn open_options_shared(options: &mut OpenOptions) -> &mut OpenOptions {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_SHARE_READ: u32 = 1;
+        options.share_mode(FILE_SHARE_READ)
+    }
+    #[cfg(not(windows))]
+    {
+        options
+    }
+}
+
+#[doc(hidden)]
+pub fn open_options_exclusive(options: &mut OpenOptions) -> &mut OpenOptions {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.share_mode(0)
+    }
+    #[cfg(not(windows))]
+    {
+        options
+    }
+}

--- a/msf/src/open.rs
+++ b/msf/src/open.rs
@@ -35,7 +35,7 @@ impl Default for CreateOptions {
 impl Msf<RandomAccessFile> {
     /// Opens an MSF file for read access, given a file name.
     pub fn open(file_name: &Path) -> anyhow::Result<Self> {
-        let file = File::open(file_name)?;
+        let file = open_options_shared(File::options().read(true)).open(file_name)?;
         let random_file = RandomAccessFile::from(file);
         Self::new_with_access_mode(random_file, AccessMode::Read)
     }
@@ -46,14 +46,16 @@ impl Msf<RandomAccessFile> {
     /// This function does not write anything to disk until stream data is written or
     /// [`Self::commit`] is called.
     pub fn create(file_name: &Path, options: CreateOptions) -> anyhow::Result<Self> {
-        let file = File::create(file_name)?;
+        let file = open_options_exclusive(File::options().read(true).write(true).create(true))
+            .open(file_name)?;
         let random_file = RandomAccessFile::from(file);
         Self::create_with_file(random_file, options)
     }
 
     /// Opens an existing MSF file for read/write access, given a file name.
     pub fn modify(file_name: &Path) -> anyhow::Result<Self> {
-        let file = File::options().read(true).write(true).open(file_name)?;
+        let file =
+            open_options_exclusive(File::options().read(true).write(true)).open(file_name)?;
         let random_file = RandomAccessFile::from(file);
         Self::modify_with_file(random_file)
     }

--- a/msfz/Cargo.toml
+++ b/msfz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb-msfz"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Reads Compressed Multi-Stream Files, which is part of the Microsoft PDB file format"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]

--- a/msfz/src/lib.rs
+++ b/msfz/src/lib.rs
@@ -17,6 +17,8 @@ pub mod spec {
     use super::*;
 }
 
+use std::fs::OpenOptions;
+
 use anyhow::Result;
 use zerocopy::{FromBytes, FromZeros, Immutable, IntoBytes, KnownLayout, Unaligned, LE, U32, U64};
 
@@ -170,4 +172,29 @@ pub const MSFZ_FILE_VERSION_V0: u64 = 0;
 /// This only looks at the signature; it doens't read anything else in the file.
 pub fn is_header_msfz(header: &[u8]) -> bool {
     header.starts_with(&MSFZ_FILE_SIGNATURE)
+}
+
+fn open_options_shared(options: &mut OpenOptions) -> &mut OpenOptions {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        const FILE_SHARE_READ: u32 = 1;
+        options.share_mode(FILE_SHARE_READ)
+    }
+    #[cfg(not(windows))]
+    {
+        options
+    }
+}
+
+fn open_options_exclusive(options: &mut OpenOptions) -> &mut OpenOptions {
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.share_mode(0)
+    }
+    #[cfg(not(windows))]
+    {
+        options
+    }
 }

--- a/msfz/src/reader.rs
+++ b/msfz/src/reader.rs
@@ -115,7 +115,7 @@ impl FragmentLocation {
 impl Msfz<RandomAccessFile> {
     /// Opens an MSFZ file and validates its header.
     pub fn open<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let f = File::open(path)?;
+        let f = open_options_shared(File::options().read(true)).open(path)?;
         let raf = RandomAccessFile::from(f);
         Self::from_file(raf)
     }

--- a/msfz/src/writer.rs
+++ b/msfz/src/writer.rs
@@ -3,6 +3,7 @@ use anyhow::anyhow;
 use pow2::Pow2;
 use std::fs::File;
 use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
 use tracing::{debug, debug_span, trace, trace_span};
 use zerocopy::IntoBytes;
 
@@ -93,6 +94,17 @@ impl std::fmt::Display for Summary {
         writeln!(f, "Number of chunks: {}", self.num_chunks)?;
         writeln!(f, "Number of streams: {}", self.num_streams)?;
         Ok(())
+    }
+}
+
+impl MsfzWriter<File> {
+    /// Creates a new writer on a file at a given path.
+    ///
+    /// This will *truncate* any existing file.
+    pub fn create(file_name: &Path) -> Result<Self> {
+        let f = open_options_exclusive(File::options().write(true).create(true).truncate(true))
+            .open(file_name)?;
+        Self::new(f)
     }
 }
 

--- a/pdb/Cargo.toml
+++ b/pdb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ms-pdb"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Reads Microsoft Program Database (PDB) files"
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -31,11 +31,11 @@ version = "0.1.3"
 path = "../codeview"
 
 [dependencies.ms-pdb-msf]
-version = "0.1.4"
+version = "0.1.5"
 path = "../msf"
 
 [dependencies.ms-pdb-msfz]
-version = "0.1.6"
+version = "0.1.7"
 path = "../msfz"
 
 [dev-dependencies]

--- a/pdb/src/lib.rs
+++ b/pdb/src/lib.rs
@@ -408,7 +408,7 @@ fn get_or_init_err<T, E, F: FnOnce() -> Result<T, E>>(cell: &OnceCell<T>, f: F) 
 impl Pdb<RandomAccessFile> {
     /// Opens a PDB file.
     pub fn open(file_name: &Path) -> anyhow::Result<Box<Pdb<RandomAccessFile>>> {
-        let f = File::open(file_name)?;
+        let f = ms_pdb_msf::open_options_shared(File::options().read(true)).open(file_name)?;
         let random_file = RandomAccessFile::from(f);
         Self::from_file_access(random_file, AccessMode::Read)
     }

--- a/pdbtool/Cargo.toml
+++ b/pdbtool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pdbtool"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "A tool for reading Program Database (PDB) files and displaying information about them."
 authors = ["Arlie Davis <ardavis@microsoft.com>"]
@@ -30,5 +30,5 @@ zerocopy.workspace = true
 zstd.workspace = true
 
 [dependencies.ms-pdb]
-version = "0.1.12"
+version = "0.1.13"
 path = "../pdb"

--- a/pdbtool/src/pdz/encode.rs
+++ b/pdbtool/src/pdz/encode.rs
@@ -63,10 +63,10 @@ pub fn pdz_encode(options: PdzEncodeOptions) -> Result<()> {
 
     let pdb = Msf::open(Path::new(&options.input_pdb))
         .with_context(|| format!("Failed to open input PDB: {}", options.input_pdb))?;
-    let out = File::create(&options.output_pdz)
+
+    let mut writer = MsfzWriter::create(Path::new(&options.output_pdz))
         .with_context(|| format!("Failed to open output PDZ: {}", options.output_pdz))?;
 
-    let mut writer = MsfzWriter::new(out)?;
     let mut stream_data: Vec<u8> = Vec::new();
     let num_streams = pdb.num_streams();
     writer.reserve_num_streams(num_streams as usize);


### PR DESCRIPTION
The `std::fs::File::open` and `std::fs::File::create` functions do not restrict file sharing. They can successfully open a file with all sharing enabled, which is usually *not* what is wanted.

This PR changes all of the public functions defined in `ms-msf`, `ms-msfz`, and `msf-pdb` so that they use appropriate sharing exclusion modes.  Functions which open files for read-only access now use `FILE_SHARE_READ` on Windows.  Functions which open files for read/write access now use `0` for a file-sharing mode, meaning exclusive mode.

This will prevent this accidental mistake:

```
pdbtool pdz-encode foo.pdb foo.pdb
```

This will open the file _concurrently_ for both read access (as a PDB) and write access (as a PDZ). This will corrupt the file.