### PR TITLE
Support `REGREL32_INDIR` and its `DEFRANGE` version

### DIFF
--- a/codeview/src/syms.rs
+++ b/codeview/src/syms.rs
@@ -635,6 +635,38 @@ impl<'a> Parse<'a> for RegRel<'a> {
     }
 }
 
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned, Debug)]
+#[allow(missing_docs)]
+pub struct RegRelIndirFixed {
+    pub offset: U32<LE>,
+    pub ty: TypeIndexLe,
+    /// Offset to be added after dereferencing [`register`][Self::register]` + `[`offset`][Self::offset].
+    pub offset_in_udt: U32<LE>,
+    pub register: U16<LE>,
+    // name: strz
+}
+
+/// `S_REGREGL32_INDIR`: This symbol specifies a symbol located relative to a dereference of a register.
+///
+/// The location in pseudocode can be expressed as `*($register + offset) + offset_in_udt`.
+/// This symbol should be used for bindings to subfields of records (e.g. C++ structured bindings).
+#[derive(Clone, Debug)]
+#[allow(missing_docs)]
+pub struct RegRelIndir<'a> {
+    pub fixed: &'a RegRelIndirFixed,
+    pub name: &'a BStr,
+}
+
+impl<'a> Parse<'a> for RegRelIndir<'a> {
+    fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
+        Ok(Self {
+            fixed: p.get()?,
+            name: p.strz()?,
+        })
+    }
+}
+
 /// Block Start: This symbol specifies the start of an inner block of lexically scoped symbols.
 /// The lexical scope is terminated by a matching `S_END` symbol.
 ///
@@ -857,6 +889,49 @@ pub struct DefRangeRegisterRelFixed {
 }
 
 impl<'a> Parse<'a> for DefRangeRegisterRel<'a> {
+    fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
+        Ok(Self {
+            fixed: p.get()?,
+            gaps: p.take_rest(),
+        })
+    }
+}
+
+#[repr(C)]
+#[derive(IntoBytes, Immutable, KnownLayout, FromBytes, Unaligned, Debug)]
+#[allow(missing_docs)]
+pub struct DefRangeRegisterRelIndirFixed {
+    /// Register to hold the base pointer of the symbol
+    pub base_reg: U16<LE>,
+
+    /// ```text
+    /// unsigned short  spilledUdtMember : 1;   // Spilled member for s.i.
+    /// unsigned short  padding          : 3;   // Padding for future use.
+    /// unsigned short  offsetParent     : CV_OFFSET_PARENT_LENGTH_LIMIT;  // Offset in parent variable.
+    /// ```
+    pub flags: U16<LE>,
+
+    /// Offset to register
+    pub base_pointer_offset: I32<LE>,
+
+    /// Offset to be added after dereferencing [`base_reg`][Self::base_reg]` + `[`base_pointer_offset`][Self::base_pointer_offset].
+    pub offset_in_udt: I32<LE>,
+
+    /// Range of addresses where this program is valid
+    pub range: LVarAddrRange,
+}
+
+/// `S_DEFRANGE_REGISTER_REL_INDIR`
+///
+/// See also [`S_REGREL32_INDIR`][RegRelIndir].
+#[derive(Clone, Debug)]
+#[allow(missing_docs)]
+pub struct DefRangeRegisterRelIndir<'a> {
+    pub fixed: &'a DefRangeRegisterRelIndirFixed,
+    pub gaps: &'a [u8],
+}
+
+impl<'a> Parse<'a> for DefRangeRegisterRelIndir<'a> {
     fn from_parser(p: &mut Parser<'a>) -> Result<Self, ParserError> {
         Ok(Self {
             fixed: p.get()?,
@@ -1534,12 +1609,14 @@ pub enum SymData<'a> {
     End,
     FrameProc(&'a FrameProc),
     RegRel(RegRel<'a>),
+    RegRelIndir(RegRelIndir<'a>),
     Block(Block<'a>),
     Local(Local<'a>),
     DefRange(DefRange<'a>),
     DefRangeFramePointerRel(DefRangeSymFramePointerRel<'a>),
     DefRangeRegister(DefRangeRegister<'a>),
     DefRangeRegisterRel(DefRangeRegisterRel<'a>),
+    DefRangeRegisterRelIndir(DefRangeRegisterRelIndir<'a>),
     DefRangeFramePointerRelFullScope(&'a DefRangeFramePointerRelFullScope),
     DefRangeSubFieldRegister(DefRangeSubFieldRegister<'a>),
     Trampoline(Trampoline<'a>),
@@ -1599,12 +1676,14 @@ impl<'a> SymData<'a> {
             SymKind::S_END => Self::End,
             SymKind::S_FRAMEPROC => Self::FrameProc(p.get()?),
             SymKind::S_REGREL32 => Self::RegRel(p.parse()?),
+            SymKind::S_REGREL32_INDIR => Self::RegRelIndir(p.parse()?),
             SymKind::S_BLOCK32 => Self::Block(p.parse()?),
             SymKind::S_LOCAL => Self::Local(p.parse()?),
             SymKind::S_DEFRANGE => Self::DefRange(p.parse()?),
             SymKind::S_DEFRANGE_FRAMEPOINTER_REL => Self::DefRangeFramePointerRel(p.parse()?),
             SymKind::S_DEFRANGE_REGISTER => Self::DefRangeRegister(p.parse()?),
             SymKind::S_DEFRANGE_REGISTER_REL => Self::DefRangeRegisterRel(p.parse()?),
+            SymKind::S_DEFRANGE_REGISTER_REL_INDIR => Self::DefRangeRegisterRelIndir(p.parse()?),
             SymKind::S_DEFRANGE_FRAMEPOINTER_REL_FULL_SCOPE => {
                 Self::DefRangeFramePointerRelFullScope(p.get()?)
             }

--- a/codeview/src/syms/kind.rs
+++ b/codeview/src/syms/kind.rs
@@ -171,6 +171,9 @@ sym_kinds! {
     0x1167, S_FASTLINK;
     0x1168, S_INLINEES;
     0x1169, S_HOTPATCHFUNC;
+
+    0x1171, S_REGREL32_INDIR;
+    0x1177, S_DEFRANGE_REGISTER_REL_INDIR;
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/pdbtool/src/dump/sym.rs
+++ b/pdbtool/src/dump/sym.rs
@@ -175,6 +175,19 @@ pub fn dump_sym(
             write!(out, " {}", reg_rel.name)?;
         }
 
+        SymData::RegRelIndir(reg_rel_indir) => {
+            let reg = reg_rel_indir.fixed.register.get();
+            let arch_reg = ArchReg::new(context.arch, reg);
+            write!(
+                out,
+                "*({arch_reg} + 0x{offset:x}) + 0x{offset_in_udt:x}, ",
+                offset = reg_rel_indir.fixed.offset.get(),
+                offset_in_udt = reg_rel_indir.fixed.offset_in_udt.get(),
+            )?;
+            ty_ref(out, context, reg_rel_indir.fixed.ty.get());
+            write!(out, " {}", reg_rel_indir.name)?;
+        }
+
         SymData::Block(block) => {
             write!(out, "length: 0x{:x}", block.fixed.length.get())?;
 
@@ -235,6 +248,14 @@ pub fn dump_sym(
                 out,
                 "base register: 0x{:x}, base pointer offset: {}",
                 r.fixed.base_reg, r.fixed.base_pointer_offset
+            )?;
+        }
+
+        SymData::DefRangeRegisterRelIndir(r) => {
+            write!(
+                out,
+                "base register: 0x{:x}, base pointer offset: {}, offset in udt: {}",
+                r.fixed.base_reg, r.fixed.base_pointer_offset, r.fixed.offset_in_udt
             )?;
         }
 


### PR DESCRIPTION
Adds support for reading and dumping `S_REGREGL32_INDIR` and `S_DEFRANGE_REGISTER_REL_INDIR`.

`S_REGREGL32_INDIR` is generated by MSVC for C++ 17 structured bindings and C++ 20 coroutines. With LLVM 23, Clang will generate the related `S_DEFRANGE_REGISTER_REL_INDIR` for this as well.

I tested it with the following code:
```cpp
struct Foo {
  int a, b;
};

int main() {
  Foo f = {1, 2};
  auto &[x, y] = f;
}
```
```
cl main.cpp /std:c++20 /GS- /Z7 /Femsvc.exe /link /nodefaultlib /entry:main
clang-cl main.cpp /GS- /std:c++20 /Z7 /Feclang.exe /link /nodefaultlib /entry:main
```

When dumping the module symbols, for MSVC, the following should show:
```
00000080 : S_GPROC32: [0001:00000010] ..+ 0x23, LF_PROCEDURE :  main
000000ac :   S_FRAMEPROC:
000000cc :   S_REGREL32_INDIR: *(RSP + 0x8) + 0x0, T_INT4 x
000000e0 :   S_REGREL32: RSP + 0x0, LF_STRUCTURE : Foo f
000000f0 :   S_REGREL32_INDIR: *(RSP + 0x8) + 0x4, T_INT4 y
00000104 :   S_END:
```
with a recent clang-cl:
```
000000d0 : S_GPROC32: [0001:00000010] ..+ 0x20, LF_PROCEDURE :  main
000000fc :   S_FRAMEPROC:
0000011c :   S_LOCAL: LF_STRUCTURE : Foo f
00000128 :   S_DEFRANGE_FRAMEPOINTER_REL: bp+ 0x8, [0001:00000014] ..+ 0x1c
00000138 :   S_LOCAL: T_INT4 x
00000144 :   S_DEFRANGE_REGISTER_REL_INDIR: base register: 0x14f, base pointer offset: 0, offset in udt: 0
0000015c :   S_LOCAL: T_INT4 y
00000168 :   S_DEFRANGE_REGISTER_REL_INDIR: base register: 0x14f, base pointer offset: 0, offset in udt: 4
00000180 :   S_END:
```