### PR TITLE
Only Big MSF containers use Page intervals

### DIFF
--- a/msf/src/open.rs
+++ b/msf/src/open.rs
@@ -151,7 +151,7 @@ impl<F: ReadAt> Msf<F> {
 
         // Create the PageAllocator. This initializes the fpm vector to "everything is free"
         // and then sets Page 0 and the FPM pages as "free". Nothing is marked as "freed".
-        let mut page_allocator = PageAllocator::new(num_pages as usize, page_size_pow2);
+        let mut page_allocator = PageAllocator::new(num_pages as usize, page_size_pow2, msf_kind);
 
         let mut committed_stream_pages: Vec<Page>;
         let mut committed_stream_page_starts: Vec<u32>;
@@ -467,14 +467,15 @@ impl<F: ReadAt> Msf<F> {
         assert!(options.page_size <= MAX_PAGE_SIZE);
 
         let num_pages: usize = 3;
+        let msf_kind: MsfKind = MsfKind::Big;
 
         let mut this = Self {
             file,
             access_mode: AccessMode::ReadWrite,
             committed_stream_pages: vec![],
             committed_stream_page_starts: vec![0; 2],
-            kind: MsfKind::Big,
-            pages: PageAllocator::new(num_pages, options.page_size),
+            kind: msf_kind,
+            pages: PageAllocator::new(num_pages, options.page_size, msf_kind),
             modified_streams: HashMap::new(),
             stream_sizes: vec![0],
             active_fpm: 2,

--- a/msf/src/pages.rs
+++ b/msf/src/pages.rs
@@ -256,6 +256,8 @@ pub(super) struct PageAllocator {
 
     pub(super) page_size: PageSize,
 
+    pub(super) msf_kind: MsfKind,
+
     /// A reusable buffer whose length is `page_size`.
     #[allow(dead_code)]
     pub(super) page_buffer: Box<[u8]>,
@@ -269,22 +271,34 @@ impl PageAllocator {
     ///
     /// We begin with setting _all_ pages free. Then we mark Page 0 and the FPM pages as busy.
     /// It is the caller's responsibility to set other bits in the FPM accordingly.
-    pub(crate) fn new(num_pages: usize, page_size: PageSize) -> Self {
+    pub(crate) fn new(num_pages: usize, page_size: PageSize, msf_kind: MsfKind) -> Self {
         let mut fpm: BitVec<u32, Lsb0> = BitVec::with_capacity(num_pages);
         fpm.resize(num_pages, true);
         fpm.set(0, false);
 
-        // Mark FPM pages as busy.
-        for interval in 0u32.. {
-            let fpm1_page = (interval << page_size.exponent()) + 1u32;
-            let fpm2_page = fpm1_page + 1u32;
-            if let Some(mut b) = fpm.get_mut(fpm1_page as usize) {
-                b.set(false);
+        match msf_kind {
+            MsfKind::Small => {
+                if let Some(mut b) = fpm.get_mut(0) {
+                    b.set(false);
+                }
+                if let Some(mut b) = fpm.get_mut(1) {
+                    b.set(false);
+                }
             }
-            if let Some(mut b) = fpm.get_mut(fpm2_page as usize) {
-                b.set(false);
-            } else {
-                break;
+            MsfKind::Big => {
+                // Mark FPM pages as busy.
+                for interval in 0u32.. {
+                    let fpm1_page = (interval << page_size.exponent()) + 1u32;
+                    let fpm2_page = fpm1_page + 1u32;
+                    if let Some(mut b) = fpm.get_mut(fpm1_page as usize) {
+                        b.set(false);
+                    }
+                    if let Some(mut b) = fpm.get_mut(fpm2_page as usize) {
+                        b.set(false);
+                    } else {
+                        break;
+                    }
+                }
             }
         }
 
@@ -301,6 +315,7 @@ impl PageAllocator {
             next_free_page_hint: 0,
             num_pages: num_pages as u32,
             page_size,
+            msf_kind,
             // unwrap() is for OOM handling
             page_buffer: FromZeros::new_box_zeroed_with_elems(usize::from(page_size)).unwrap(),
         }
@@ -566,29 +581,31 @@ impl PageAllocator {
 
         // Check that the pages assigned to the FPM are marked "busy" in all intervals.
 
-        let mut interval: u32 = 0;
-        loop {
-            let p = (interval << self.page_size.exponent()) as usize;
-            let fpm1_index = p + 1;
-            let fpm2_index = p + 2;
+        if self.msf_kind == MsfKind::Big {
+            let mut interval: u32 = 0;
+            loop {
+                let p = (interval << self.page_size.exponent()) as usize;
+                let fpm1_index = p + 1;
+                let fpm2_index = p + 2;
 
-            if fpm1_index < self.fpm.len() {
-                assert!(!self.fpm[fpm1_index], "All FPM pages should be marked BUSY");
-                assert!(
-                    !self.fpm_freed[fpm1_index],
-                    "FPM pages should never be deleted"
-                );
-            }
+                if fpm1_index < self.fpm.len() {
+                    assert!(!self.fpm[fpm1_index], "All FPM pages should be marked BUSY");
+                    assert!(
+                        !self.fpm_freed[fpm1_index],
+                        "FPM pages should never be deleted"
+                    );
+                }
 
-            if fpm2_index < self.fpm.len() {
-                assert!(!self.fpm[fpm2_index], "All FPM pages should be marked BUSY");
-                assert!(
-                    !self.fpm_freed[fpm2_index],
-                    "FPM pages should never be deleted"
-                );
-                interval += 1;
-            } else {
-                break;
+                if fpm2_index < self.fpm.len() {
+                    assert!(!self.fpm[fpm2_index], "All FPM pages should be marked BUSY");
+                    assert!(
+                        !self.fpm_freed[fpm2_index],
+                        "FPM pages should never be deleted"
+                    );
+                    interval += 1;
+                } else {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #59


With this patch, parsing a non-trivial PDB that uses the small MSF container format continues until it hits https://github.com/microsoft/pdb-rs/issues/58.


note: this is my first rust PR. Feedback would be appreciated.